### PR TITLE
Provide analyzer + code fix for turning sync command to async and viceversa

### DIFF
--- a/src/Merq.CodeAnalysis/CommandHandlerAnalyzer.cs
+++ b/src/Merq.CodeAnalysis/CommandHandlerAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -37,76 +36,53 @@ public class CommandHandlerAnalyzer : DiagnosticAnalyzer
             return;
 
         if (declaration.BaseList?.ChildNodes().OfType<SimpleBaseTypeSyntax>()
-            .Where(x => x.Type is GenericNameSyntax generic)
-            .Select(x => (GenericNameSyntax)x.Type)
-            .Where(x => x.Identifier.ToString() == "ICommandHandler" || x.Identifier.ToString() == "IAsyncCommandHandler")
-            .FirstOrDefault() is not GenericNameSyntax handlerName)
+            .Select(x => (x.Type, Symbol: semantic.GetSymbolInfo(x.Type).Symbol as INamedTypeSymbol))
+            .Where(x => x.Symbol is not null && x.Symbol.IsGenericType)
+            .FirstOrDefault(x => x.Symbol!.Name == "ICommandHandler" || x.Symbol.Name == "IAsyncCommandHandler") is not var (type, symbol))
             return;
 
-        if (semantic.GetSymbolInfo(handlerName).Symbol is not INamedTypeSymbol handlerSymbol ||
-            !handlerSymbol.IsGenericType)
-            return;
-
+        (var handlerName, var handlerSymbol) = (type, symbol);
         var asyncCmd = context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommand`1");
         var syncCmd = context.Compilation.GetTypeByMetadataName("Merq.ICommand`1");
 
         if (asyncCmd == null || syncCmd == null)
             return;
 
+        if (handlerSymbol.TypeArguments[0] is not INamedTypeSymbol cmdSymbol)
+            return;
+
+        var cmdInterface = cmdSymbol.AllInterfaces
+                .Where(i => i.IsGenericType)
+                .FirstOrDefault(i =>
+                    i.ConstructedFrom.Equals(asyncCmd, SymbolEqualityComparer.Default) ||
+                    i.ConstructedFrom.Equals(syncCmd, SymbolEqualityComparer.Default));
+
+        if (cmdInterface == null)
+            return;
+
         if (handlerSymbol.TypeArguments.Length == 1)
         {
-            if (handlerSymbol.TypeArguments[0] is INamedTypeSymbol cmdSymbol &&
-                cmdSymbol.AllInterfaces
-                    .Where(i => i.IsGenericType)
-                    .FirstOrDefault(i =>
-                        i.ConstructedFrom.Equals(asyncCmd, SymbolEqualityComparer.Default) ||
-                        i.ConstructedFrom.Equals(syncCmd, SymbolEqualityComparer.Default)) is INamedTypeSymbol cmdInterface)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.MissingCommandReturnType,
-                    handlerName.GetLocation(),
-                    ImmutableDictionary<string, string?>.Empty
-                        .Add("CommandType", cmdSymbol.ToFullName())
-                        .Add("ReturnType", cmdInterface.TypeArguments[0].ToFullName()),
-                    cmdInterface.TypeArguments[0].ToMinimalDisplayString(semantic, context.Node.SpanStart)));
-            }
+            context.ReportDiagnostic(Diagnostic.Create(Diagnostics.MissingCommandReturnType,
+                handlerName.GetLocation(),
+                ImmutableDictionary<string, string?>.Empty
+                    .Add("TCommand", cmdSymbol.ToFullName())
+                    .Add("TReturn", cmdInterface.TypeArguments[0].ToFullName()),
+                cmdInterface.TypeArguments[0].ToMinimalDisplayString(semantic, context.Node.SpanStart)));
         }
-        else if (handlerSymbol.TypeArguments.Length == 2)
+        else if (handlerSymbol.TypeArguments.Length == 2 &&
+            !cmdInterface.TypeArguments[0].Equals(handlerSymbol.TypeArguments[1], SymbolEqualityComparer.Default))
         {
-            if (handlerSymbol.TypeArguments[0] is INamedTypeSymbol cmdSymbol &&
-                cmdSymbol.AllInterfaces
-                    .Where(i => i.IsGenericType)
-                    .FirstOrDefault(i =>
-                        i.ConstructedFrom.Equals(asyncCmd, SymbolEqualityComparer.Default) ||
-                        i.ConstructedFrom.Equals(syncCmd, SymbolEqualityComparer.Default)) is INamedTypeSymbol cmdInterface &&
-                !cmdInterface.TypeArguments[0].Equals(handlerSymbol.TypeArguments[1], SymbolEqualityComparer.Default))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(Diagnostics.WrongCommandReturnType,
-                    handlerName.GetLocation(),
-                    ImmutableDictionary<string, string?>.Empty
-                        .Add("CommandType", cmdSymbol.ToFullName())
-                        .Add("ReturnType", cmdInterface.TypeArguments[0].ToFullName()),
-                    handlerSymbol.TypeArguments[1].ToMinimalDisplayString(semantic, context.Node.SpanStart),
-                    cmdSymbol.ToMinimalDisplayString(semantic, context.Node.SpanStart),
-                    cmdInterface.TypeArguments[0].ToMinimalDisplayString(semantic, context.Node.SpanStart)));
-            }
+            context.ReportDiagnostic(Diagnostic.Create(Diagnostics.WrongCommandReturnType,
+                handlerName.GetLocation(),
+                ImmutableDictionary<string, string?>.Empty
+                    .Add("TCommand", cmdSymbol.ToFullName())
+                    .Add("TReturn", cmdInterface.TypeArguments[0].ToFullName())
+                    .Add("TInterface", handlerSymbol.Name == "ICommandHandler" ?
+                        syncCmd.Construct(handlerSymbol.TypeArguments[1]).ToFullName() :
+                        asyncCmd.Construct(handlerSymbol.TypeArguments[1]).ToFullName()),
+                handlerSymbol.TypeArguments[1].ToMinimalDisplayString(semantic, context.Node.SpanStart),
+                cmdSymbol.ToMinimalDisplayString(semantic, context.Node.SpanStart),
+                cmdInterface.TypeArguments[0].ToMinimalDisplayString(semantic, context.Node.SpanStart)));
         }
-    }
-
-    static bool IsType(ITypeSymbol? expected, ITypeSymbol? actual)
-    {
-        if (expected == null || actual == null)
-            return false;
-
-        if (actual.Equals(expected, SymbolEqualityComparer.Default) == true)
-            return true;
-
-        if (expected.BaseType?.Name.Equals("object", StringComparison.OrdinalIgnoreCase) == true)
-            return false;
-
-        foreach (var iface in actual.AllInterfaces)
-            if (iface.Equals(expected, SymbolEqualityComparer.Default) == true)
-                return true;
-
-        return IsType(expected.BaseType, actual);
     }
 }

--- a/src/Merq.CodeAnalysis/CommandInterfaceAnalyzer.cs
+++ b/src/Merq.CodeAnalysis/CommandInterfaceAnalyzer.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Merq;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CommandInterfaceAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(
+            Diagnostics.WrongCommandInterface);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(c =>
+        {
+            c.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.ClassDeclaration);
+            c.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.RecordDeclaration);
+        });
+    }
+
+    static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+    {
+        var declaration = (TypeDeclarationSyntax)context.Node;
+        var semantic = context.SemanticModel;
+        if (declaration.BaseList?.ChildNodes().OfType<SimpleBaseTypeSyntax>()
+            .Select(x => (x.Type, Symbol: semantic.GetSymbolInfo(x.Type).Symbol as INamedTypeSymbol))
+            .Where(x => x.Symbol is not null && x.Symbol.IsGenericType)
+            .FirstOrDefault(x => x.Symbol!.Name == "ICommandHandler" || x.Symbol.Name == "IAsyncCommandHandler") is not var (typeSyntax, handlerSymbol) ||
+            typeSyntax.DescendantNodesAndSelf().OfType<GenericNameSyntax>().FirstOrDefault() is not GenericNameSyntax handlerName ||
+            !handlerSymbol.IsGenericType ||
+            handlerSymbol.TypeArguments[0] is not INamedTypeSymbol commandSymbol ||
+            handlerName.TypeArgumentList.Arguments[0] is not TypeSyntax commandSyntax ||
+            context.Compilation.GetTypeByMetadataName("Merq.ICommand") is not INamedTypeSymbol syncCmd ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommand") is not INamedTypeSymbol asyncCmd ||
+            context.Compilation.GetTypeByMetadataName("Merq.ICommand`1") is not INamedTypeSymbol syncCmdRet ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommand`1") is not INamedTypeSymbol asyncCmdRet ||
+            context.Compilation.GetTypeByMetadataName("Merq.ICommandHandler`1") is not INamedTypeSymbol syncHandler ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommandHandler`1") is not INamedTypeSymbol asyncHandler ||
+            context.Compilation.GetTypeByMetadataName("Merq.ICommandHandler`2") is not INamedTypeSymbol syncHandlerRet ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommandHandler`2") is not INamedTypeSymbol asyncHandlerRet)
+            return;
+
+        var isAsync = handlerSymbol.Is(asyncHandler) || handlerSymbol.Is(asyncHandlerRet);
+        var isSync = handlerSymbol.Is(syncHandler) || handlerSymbol.Is(syncHandlerRet);
+        var handlerHasReturn = handlerSymbol.Is(asyncHandlerRet) || handlerSymbol.Is(syncHandlerRet);
+        var commandHasReturn = commandSymbol.Is(asyncCmdRet) || commandSymbol.Is(syncCmdRet);
+        var location = typeSyntax.GetLocation();
+        var expectedInterface = handlerHasReturn ?
+            (isAsync ? asyncCmdRet : syncCmdRet).Construct(handlerSymbol.TypeArguments[1]) :
+            (isAsync ? asyncCmd : syncCmd);
+
+        if (commandSymbol.Is(expectedInterface))
+            return;
+
+        var commandInterface = commandSymbol.AllInterfaces
+            .Where(i => i.IsGenericType)
+            .FirstOrDefault(i =>
+                i.ConstructedFrom.Equals(asyncCmd, SymbolEqualityComparer.Default) ||
+                i.ConstructedFrom.Equals(syncCmd, SymbolEqualityComparer.Default) ||
+                i.ConstructedFrom.Equals(asyncCmdRet, SymbolEqualityComparer.Default) ||
+                i.ConstructedFrom.Equals(syncCmdRet, SymbolEqualityComparer.Default));
+
+        var properties = ImmutableDictionary<string, string?>.Empty
+            .Add("TCommand", commandSymbol.ToFullName())
+            .Add("TInterface", expectedInterface.ToFullName());
+
+        if (isAsync)
+            properties = properties.Add("IsAsync", "true");
+
+        if (handlerHasReturn)
+            properties = properties.Add("TResult", handlerSymbol.TypeArguments[1].ToFullName());
+
+        // no interface at all
+        if (commandInterface == null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.WrongCommandInterface, location,
+                properties.Add("Add", "true"),
+                commandSymbol.Name,
+                expectedInterface.ToMinimalDisplayString(semantic, declaration.SpanStart)));
+        }
+        // sync/async mismatch
+        else if (isAsync && !(commandSymbol.Is(asyncCmd) || commandSymbol.Is(asyncCmdRet)))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.WrongCommandInterface, location, properties, commandSymbol.Name,
+                "IAsyncCommand"));
+        }
+        else if (isSync && !(commandSymbol.Is(syncCmd) || commandSymbol.Is(syncCmdRet)))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.WrongCommandInterface, location, properties, commandSymbol.Name,
+                "ICommand"));
+        }
+        // void/ret mismatch
+        else if ((handlerHasReturn && !commandHasReturn) ||
+            (!handlerHasReturn && commandHasReturn))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.WrongCommandInterface, location, properties, commandSymbol.Name,
+                expectedInterface.ToMinimalDisplayString(semantic, declaration.SpanStart)));
+        }
+        // return type mismatch
+        else if (handlerHasReturn && commandHasReturn &&
+            !handlerSymbol.TypeArguments[1].Equals(commandInterface.TypeArguments[0], SymbolEqualityComparer.Default))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.WrongCommandInterface, location, properties, commandSymbol.Name,
+                expectedInterface.ToMinimalDisplayString(semantic, declaration.SpanStart)));
+        }
+    }
+}

--- a/src/Merq.CodeAnalysis/Diagnostics.cs
+++ b/src/Merq.CodeAnalysis/Diagnostics.cs
@@ -39,4 +39,13 @@ public static class Diagnostics
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Command handlers must specify the same return type as the command they handle.");
+
+    public static DiagnosticDescriptor WrongCommandInterface { get; } = new(
+        "MERQ005",
+        "Command interface mismatch",
+        "Command '{0}' does not implement interface '{1}' required by command handler.",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Commands must implement the interface that matches the handler's.");
 }

--- a/src/Merq.CodeAnalysis/SymbolExtensions.cs
+++ b/src/Merq.CodeAnalysis/SymbolExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+
+namespace Merq;
+
+static class SymbolExtensions
+{
+    /// <summary>
+    /// Checks whether the <paramref name="this"/> type inherits or implements the 
+    /// <paramref name="baseTypeOrInterface"/> type, even if it's a generic type.
+    /// </summary>
+    public static bool Is(this ITypeSymbol? @this, ITypeSymbol? baseTypeOrInterface)
+    {
+        if (@this == null || baseTypeOrInterface == null)
+            return false;
+
+        if (@this.Equals(baseTypeOrInterface, SymbolEqualityComparer.Default) == true)
+            return true;
+
+        if (baseTypeOrInterface is INamedTypeSymbol namedExpected &&
+            @this is INamedTypeSymbol namedActual &&
+            namedActual.IsGenericType &&
+            namedActual.ConstructedFrom.Equals(namedExpected, SymbolEqualityComparer.Default))
+            return true;
+
+        foreach (var iface in @this.AllInterfaces)
+            if (iface.Is(baseTypeOrInterface))
+                return true;
+
+        if (@this.BaseType?.Name.Equals("object", StringComparison.OrdinalIgnoreCase) == true)
+            return false;
+
+        return Is(@this.BaseType, baseTypeOrInterface);
+    }
+}

--- a/src/Merq.CodeAnalysis/SymbolFullNameExtensions.cs
+++ b/src/Merq.CodeAnalysis/SymbolFullNameExtensions.cs
@@ -30,8 +30,9 @@ public static class SymbolFullNameExtensions
     /// <summary>
     /// Resolves a symbol given its full name, as returned by <see cref="ToFullName(ITypeSymbol)"/>.
     /// </summary>
-    public static ITypeSymbol? GetTypeByFullName(this Compilation compilation, string symbolFullName)
-        => new SymbolResolver(compilation).Resolve(symbolFullName ?? throw new ArgumentNullException(nameof(symbolFullName)));
+    public static ITypeSymbol? GetTypeByFullName(this Compilation compilation, string? symbolFullName)
+        => symbolFullName == null ? null :
+            new SymbolResolver(compilation).Resolve(symbolFullName);
 
     class SymbolResolver
     {

--- a/src/Merq.CodeFixes/CommandInterfaceFixer.cs
+++ b/src/Merq.CodeFixes/CommandInterfaceFixer.cs
@@ -1,0 +1,193 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Merq.CodeFixes;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class CommandInterfaceFixer : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+        Diagnostics.WrongCommandInterface.Id,
+        Diagnostics.WrongCommandReturnType.Id);
+
+    public override FixAllProvider? GetFixAllProvider() => null;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var changeReturn = context.Diagnostics.FirstOrDefault(x => x.Id == Diagnostics.WrongCommandReturnType.Id);
+
+        if (context.Diagnostics.FirstOrDefault() is not Diagnostic diagnostic ||
+            !diagnostic.Properties.TryGetValue("TCommand", out var commandType) ||
+            commandType is null ||
+            !diagnostic.Properties.TryGetValue("TInterface", out var interfaceType) ||
+            interfaceType is null ||
+            await context.Document.GetSemanticModelAsync(context.CancellationToken) is not SemanticModel semantic ||
+            await context.Document.Project.GetCompilationAsync(context.CancellationToken) is not Compilation compilation ||
+            compilation.GetTypeByFullName(commandType) is not INamedTypeSymbol commandSymbol ||
+            compilation.GetTypeByFullName(interfaceType) is not INamedTypeSymbol interfaceSymbol ||
+            commandSymbol.DeclaringSyntaxReferences.FirstOrDefault() is not SyntaxReference commandReference ||
+            await commandReference.GetSyntaxAsync(context.CancellationToken) is not TypeDeclarationSyntax commandSyntax ||
+            context.Document.Project.GetDocument(commandReference.SyntaxTree) is not Document commandDocument)
+            return;
+
+        var title = $"Implement '{interfaceSymbol.ToMinimalDisplayString(semantic, context.Span.Start)}' on '{commandSymbol.Name}'";
+        string? returnType = default;
+
+        if (changeReturn is not null)
+        {
+            returnType = interfaceSymbol.TypeArguments[0].ToFullName();
+            title = $"Change command return type to '{interfaceSymbol.TypeArguments[0].ToMinimalDisplayString(semantic, context.Span.Start)}' for '{commandSymbol.Name}'";
+        }
+
+        context.RegisterCodeFix(new SetCommandInterfaceAction(new Args(
+            context.Document, commandDocument, context.Span, title, compilation, semantic,
+            commandSyntax, commandSymbol, commandType, interfaceSymbol, interfaceType, returnType)), diagnostic);
+    }
+
+    record Args(
+        Document HandlerDocument,
+        Document CommandDocument, TextSpan Span, string Title, Compilation Compilation, SemanticModel Semantic,
+        TypeDeclarationSyntax CommandSyntax,
+        INamedTypeSymbol CommandSymbol, string CommandType,
+        INamedTypeSymbol InterfaceSymbol, string InterfaceTypeName, string? ReturnType)
+    {
+        // It makes sense for the command + interface names used in the code fix action title to be minimal 
+        // with regards to the codefix action context, rather than the command declaration context which could 
+        // be an entirely different file with different usings.
+        //public string CommandName { get; } = CommandSymbol.ToMinimalDisplayString(Semantic, Span.Start);
+        //public string InterfaceName { get; } = InterfaceSymbol.ToMinimalDisplayString(Semantic, Span.Start);
+    }
+
+    class SetCommandInterfaceAction : CodeAction
+    {
+        readonly Args args;
+
+        public SetCommandInterfaceAction(Args args) => this.args = args;
+
+        public override string Title => args.Title;
+
+        public override string? EquivalenceKey => Title;
+
+        protected override async Task<Solution?> GetChangedSolutionAsync(CancellationToken cancellationToken)
+        {
+            var root = await args.CommandDocument.GetSyntaxRootAsync(cancellationToken);
+            if (root == null)
+                return args.CommandDocument.Project.Solution;
+
+            // Add annotation to command syntax node for easier tracking
+            root = root.ReplaceNode(args.CommandSyntax, args.CommandSyntax.WithAdditionalAnnotations(new SyntaxAnnotation("CommandSyntax")));
+            var document = args.CommandDocument.WithSyntaxRoot(root);
+            root = await document.GetSyntaxRootAsync(cancellationToken);
+
+            if (root == null ||
+                root.GetAnnotatedNodes("CommandSyntax").OfType<TypeDeclarationSyntax>().FirstOrDefault() is not TypeDeclarationSyntax commandSyntax ||
+                await document.GetSemanticModelAsync(cancellationToken) is not SemanticModel semantic ||
+                await document.Project.GetCompilationAsync(cancellationToken) is not Compilation compilation ||
+                compilation.GetTypeByFullName(args.ReturnType) is not INamedTypeSymbol returnType ||
+                compilation.GetTypeByFullName(args.CommandType) is not INamedTypeSymbol commandSymbol)
+                return args.CommandDocument.Project.Solution;
+
+            if (args.ReturnType != null &&
+                document.Project.GetDocument(args.HandlerDocument.Id) is Document handlerDoc &&
+                await handlerDoc.GetSemanticModelAsync(cancellationToken) is SemanticModel handlerSemantic &&
+                await handlerDoc.GetSyntaxRootAsync(cancellationToken) is SyntaxNode handlerRoot)
+            {
+                var rewriter = new ExecuteReturnRewriter(handlerSemantic, commandSymbol,
+                    returnType.ToMinimalDisplayString(handlerSemantic, args.Span.Start));
+
+                handlerDoc = handlerDoc.WithSyntaxRoot(rewriter.Visit(handlerRoot));
+                document = handlerDoc.Project.GetDocument(document.Id);
+                if (document == null)
+                    return args.CommandDocument.Project.Solution;
+
+                root = await document.GetSyntaxRootAsync(cancellationToken);
+                if (root?.GetAnnotatedNodes("CommandSyntax").OfType<TypeDeclarationSyntax>().FirstOrDefault() is not TypeDeclarationSyntax syntax)
+                    return args.CommandDocument.Project.Solution;
+
+                commandSyntax = syntax;
+
+                if (await document.GetSemanticModelAsync(cancellationToken) is not SemanticModel model)
+                    return args.CommandDocument.Project.Solution;
+
+                semantic = model;
+            }
+
+            // Determine if document contains import for Merq namespace
+            if (root.DescendantNodes(node => node.IsKind(SyntaxKind.CompilationUnit) || node.IsKind(SyntaxKind.NamespaceDeclaration))
+                    .OfType<UsingDirectiveSyntax>()
+                    .FirstOrDefault(node => node.Name.ToString() == "Merq") is null &&
+                root.DescendantNodesAndSelf()
+                    .OfType<CompilationUnitSyntax>()
+                    .FirstOrDefault() is CompilationUnitSyntax unit)
+            {
+                var usingMerq = UsingDirective(IdentifierName("Merq")).WithTrailingTrivia(CarriageReturnLineFeed);
+
+                if (unit
+                    .DescendantNodes(node => node.IsKind(SyntaxKind.NamespaceDeclaration))
+                    .OfType<UsingDirectiveSyntax>()
+                    .LastOrDefault() is UsingDirectiveSyntax lastUsing &&
+                    lastUsing.Parent != null)
+                {
+                    root = root.ReplaceNode(
+                        lastUsing.Parent,
+                        lastUsing.Parent.InsertNodesAfter(lastUsing, new[] { usingMerq }));
+                }
+                else if (unit
+                    .ChildNodes()
+                    .OfType<NamespaceDeclarationSyntax>()
+                    .LastOrDefault() is NamespaceDeclarationSyntax lastNamespace)
+                {
+                    root = root.ReplaceNode(lastNamespace, lastNamespace.AddUsings(usingMerq));
+                }
+                else
+                {
+                    // It's fine adding to the top, since we didn't find other usings, or we have a 
+                    // FileScopedNamespaceDeclarationSyntax instead of a NamespaceDeclarationSyntax
+                    root = root.ReplaceNode(unit, unit.AddUsings(usingMerq));
+                }
+
+                document = document.WithSyntaxRoot(root);
+                root = await document.GetSyntaxRootAsync(cancellationToken);
+                if (root?.GetAnnotatedNodes("CommandSyntax").OfType<TypeDeclarationSyntax>().FirstOrDefault() is not TypeDeclarationSyntax syntax)
+                    return args.CommandDocument.Project.Solution;
+
+                commandSyntax = syntax;
+                if (await document.GetSemanticModelAsync(cancellationToken) is not SemanticModel model)
+                    return args.CommandDocument.Project.Solution;
+
+                semantic = model;
+            }
+
+            if (await document.Project.GetCompilationAsync(cancellationToken) is not Compilation comp ||
+                comp.GetTypeByFullName(args.InterfaceTypeName) is not INamedTypeSymbol interfaceSymbol)
+                return args.CommandDocument.Project.Solution;
+
+            var interfaceSyntax = ParseTypeName(interfaceSymbol.ToMinimalDisplayString(semantic, commandSyntax.SpanStart));
+
+            var existingInterface = commandSyntax.BaseList?.Types
+                .Select(x => (Syntax: x, semantic.GetSymbolInfo(x.Type).Symbol))
+                .FirstOrDefault(x => x.Symbol is INamedTypeSymbol symbol && (symbol.Name == "ICommand" || symbol.Name == "IAsyncCommand"));
+
+            if (existingInterface?.Symbol is not null)
+            {
+                return document.WithSyntaxRoot(root.ReplaceNode(existingInterface.Value.Syntax,
+                    existingInterface.Value.Syntax.WithType(interfaceSyntax))).Project.Solution;
+            }
+
+            return document.WithSyntaxRoot(root.ReplaceNode(commandSyntax,
+                commandSyntax.AddBaseListTypes(SimpleBaseType(interfaceSyntax)))).Project.Solution;
+        }
+    }
+}

--- a/src/Merq.CodeFixes/ExecuteReturnRewriter.cs
+++ b/src/Merq.CodeFixes/ExecuteReturnRewriter.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Merq;
+
+class ExecuteReturnRewriter : CSharpSyntaxRewriter
+{
+    readonly SemanticModel semantic;
+    readonly INamedTypeSymbol commandSymbol;
+    readonly string returnType;
+
+    public ExecuteReturnRewriter(SemanticModel semantic, INamedTypeSymbol commandSymbol, string returnType)
+        => (this.semantic, this.commandSymbol, this.returnType)
+        = (semantic, commandSymbol, returnType);
+
+    public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        if (node.ParameterList.Parameters.Count < 1 ||
+            node.ParameterList.Parameters.Count > 2)
+            return node;
+
+        if (node.ParameterList.Parameters[0].Type is not TypeSyntax parameterSyntax ||
+            semantic.GetSymbolInfo(parameterSyntax).Symbol is not ITypeSymbol parameterType ||
+            !parameterType.Equals(commandSymbol, SymbolEqualityComparer.Default))
+            return node;
+
+        if (node.Identifier.ToString() == "Execute")
+        {
+            return node.WithReturnType(ParseTypeName(returnType).WithTrailingTrivia(Space));
+        }
+        else if (node.Identifier.ToString() == "ExecuteAsync")
+        {
+            if (node.ReturnType is GenericNameSyntax generic)
+                return node.WithReturnType(generic
+                    .WithTypeArgumentList(
+                        TypeArgumentList(
+                            SeparatedList(new[] { ParseTypeName(returnType) }))));
+            else
+                return node.WithReturnType(
+                    GenericName(Identifier("Task"))
+                        .WithTypeArgumentList(
+                            TypeArgumentList(
+                                SeparatedList(new[] { ParseTypeName(returnType) }))));
+        }
+
+        return node;
+    }
+}

--- a/src/Merq.CodeFixes/Merq.CodeFixes.csproj
+++ b/src/Merq.CodeFixes/Merq.CodeFixes.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" Version="0.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Pack="false" Version="4.2.0"  />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Pack="false" Version="4.2.0" />
+    <PackageReference Include="PolySharp" Version="1.7.1" />
     <PackageReference Include="Superpower" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Merq.CodeFixes/SetCommandReturnTypeFixer.cs
+++ b/src/Merq.CodeFixes/SetCommandReturnTypeFixer.cs
@@ -1,13 +1,11 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -33,13 +31,12 @@ public class SetCommandReturnTypeFixer : CodeFixProvider
             return;
 
         if (context.Diagnostics.FirstOrDefault() is not Diagnostic diagnostic ||
-            !diagnostic.Properties.TryGetValue("CommandType", out var commandType) ||
+            !diagnostic.Properties.TryGetValue("TCommand", out var commandType) ||
             commandType is null ||
-            !diagnostic.Properties.TryGetValue("ReturnType", out var returnType) ||
+            !diagnostic.Properties.TryGetValue("TReturn", out var returnType) ||
             returnType is null ||
             await context.Document.GetSemanticModelAsync(context.CancellationToken) is not SemanticModel semantic ||
             await context.Document.Project.GetCompilationAsync(context.CancellationToken) is not Compilation compilation ||
-            compilation.GetTypeByFullName(commandType) is not INamedTypeSymbol commandSymbol ||
             compilation.GetTypeByFullName(returnType) is not INamedTypeSymbol returnSymbol)
             return;
 
@@ -47,7 +44,7 @@ public class SetCommandReturnTypeFixer : CodeFixProvider
                 compilation,
                 context.Document,
                 root, typeSyntax,
-                commandSymbol,
+                commandType,
                 returnSymbol.ToMinimalDisplayString(semantic, context.Span.Start)),
             context.Diagnostics);
     }
@@ -57,35 +54,34 @@ public class SetCommandReturnTypeFixer : CodeFixProvider
         readonly Document document;
         readonly SyntaxNode root;
         readonly SimpleBaseTypeSyntax baseType;
-        readonly INamedTypeSymbol commandSymbol;
+        readonly string commandType;
         readonly string returnType;
 
-        public SetCommandReturnTypeAction(Compilation compilation, Document document, SyntaxNode root, SimpleBaseTypeSyntax typeSyntax, INamedTypeSymbol commandSymbol, string returnType)
-            => (this.document, this.root, baseType, this.commandSymbol, this.returnType)
-            = (document, root, typeSyntax, commandSymbol, returnType);
+        public SetCommandReturnTypeAction(Compilation compilation, Document document, SyntaxNode root, SimpleBaseTypeSyntax typeSyntax, string commandType, string returnType)
+            => (this.document, this.root, baseType, this.commandType, this.returnType)
+            = (document, root, typeSyntax, commandType, returnType);
 
-        public override string Title => $"Specify command return type {returnType}";
+        public override string Title => $"Fix command handler return type to '{returnType}'";
         public override string EquivalenceKey => Title;
 
         protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
         {
-            var baseType = this.baseType;
-            if (baseType.Type is not GenericNameSyntax genericName ||
-                await document.GetSemanticModelAsync(cancellationToken) is not SemanticModel semantic)
-                return document;
+            // Annotate generic name for tracking
+            var root = this.root.ReplaceNode(this.baseType, this.baseType.WithAdditionalAnnotations(new SyntaxAnnotation("BaseType")));
+            var document = this.document.WithSyntaxRoot(root);
+            root = await document.GetSyntaxRootAsync(cancellationToken);
 
-            var root = new MethodReturnTypeRewriter(semantic, commandSymbol, returnType).Visit(this.root);
+            if (await document.Project.GetCompilationAsync(cancellationToken) is not Compilation compilation ||
+                await document.GetSemanticModelAsync(cancellationToken) is not SemanticModel semantic ||
+                compilation.GetTypeByFullName(commandType) is not INamedTypeSymbol commandSymbol ||
+                root == null)
+                return this.document;
 
-            // If we cannot locate again the baseType, then 
-            // we backtrack, since it's more important to fix the interface than the method.
-            if (root.FindNode(genericName.Span) is not SimpleBaseTypeSyntax newBaseType ||
-                newBaseType.Type is not GenericNameSyntax newGenericName)
-                root = this.root;
-            else
-            {
-                genericName = newGenericName;
-                baseType = newBaseType;
-            }
+            root = new ExecuteReturnRewriter(semantic, commandSymbol, returnType).Visit(root);
+            var baseType = (SimpleBaseTypeSyntax)root.GetAnnotatedNodes("BaseType").Single();
+
+            if (baseType.Type.DescendantNodesAndSelf().OfType<GenericNameSyntax>().FirstOrDefault() is not GenericNameSyntax genericName)
+                return this.document;
 
             if (genericName.TypeArgumentList.Arguments.Count == 2)
             {
@@ -110,48 +106,5 @@ public class SetCommandReturnTypeFixer : CodeFixProvider
             }
         }
 
-        class MethodReturnTypeRewriter : CSharpSyntaxRewriter
-        {
-            readonly SemanticModel semantic;
-            readonly INamedTypeSymbol commandSymbol;
-            readonly string returnType;
-
-            public MethodReturnTypeRewriter(SemanticModel semantic, INamedTypeSymbol commandSymbol, string returnType)
-                => (this.semantic, this.commandSymbol, this.returnType)
-                = (semantic, commandSymbol, returnType);
-
-            public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
-            {
-                if (node.ParameterList.Parameters.Count < 1 ||
-                    node.ParameterList.Parameters.Count > 2)
-                    return node;
-
-                if (node.ParameterList.Parameters[0].Type is not TypeSyntax parameterSyntax ||
-                    semantic.GetSymbolInfo(parameterSyntax).Symbol is not ITypeSymbol parameterType ||
-                    !parameterType.Equals(commandSymbol, SymbolEqualityComparer.Default))
-                    return node;
-
-                if (node.Identifier.ToString() == "Execute")
-                {
-                    return node.WithReturnType(ParseTypeName(returnType).WithTrailingTrivia(Space));
-                }
-                else if (node.Identifier.ToString() == "ExecuteAsync")
-                {
-                    if (node.ReturnType is GenericNameSyntax generic)
-                        return node.WithReturnType(generic
-                            .WithTypeArgumentList(
-                                TypeArgumentList(
-                                    SeparatedList(new[] { ParseTypeName(returnType) }))));
-                    else
-                        return node.WithReturnType(
-                            GenericName(Identifier("Task"))
-                                .WithTypeArgumentList(
-                                    TypeArgumentList(
-                                        SeparatedList(new[] { ParseTypeName(returnType) }))));
-                }
-
-                return node;
-            }
-        }
     }
 }


### PR DESCRIPTION
The new analyer detects the need for changes in the command definition itself, allowing the command handler to drive changes to it in a more automated fashion, as follows:

* If during the command implementation, you find that the command needs to be made async, you can just change implemented interface in the handler from ICommandHandler > IAsyncCommandHandler and an analyzer + codefix will suggest changing the command from ICommand to IAsyncCommand in turn.
* If during the implementation, you find that you'd like to return a value, or perhaps even change the return type you previously had, an analyzer + codefix will suggest the relevant changes to the command too, setting/removing the return type as needed (by changing the ICommand<TResult> or IAsyncCommand<TResult> as needed, even removing the TResult entirely as needed.

Closes #38