### PR TITLE
Issue a warning for non-public commands

### DIFF
--- a/src/Merq.CodeAnalysis/Diagnostics.cs
+++ b/src/Merq.CodeAnalysis/Diagnostics.cs
@@ -75,4 +75,16 @@ public static class Diagnostics
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "In order to support automatic hierarchical dynamic conversion for records, the Create method must be accessible within the compilation.");
+
+    /// <summary>
+    /// MERQ007: Consider making command types public.
+    /// </summary>
+    public static DiagnosticDescriptor CommandTypesShouldBePublic { get; } = new(
+        "MERQ007",
+        "Consider making command types public",
+        "Consider making command '{0}' public.",
+        "Design",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Public commands have better performance characteristics when dynamic conversion (aka 'duck-typing') is used.");
 }

--- a/src/Merq.CodeAnalysis/PublicCommandAnalyzer.cs
+++ b/src/Merq.CodeAnalysis/PublicCommandAnalyzer.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Merq;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class PublicCommandAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Diagnostics.CommandTypesShouldBePublic);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeTypeSymbol, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeTypeSymbol(SymbolAnalysisContext context)
+    {
+        var namedType = (INamedTypeSymbol)context.Symbol;
+        if (context.Compilation.GetTypeByMetadataName("Merq.ICommand") is not INamedTypeSymbol syncCmd ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommand") is not INamedTypeSymbol asyncCmd ||
+            context.Compilation.GetTypeByMetadataName("Merq.ICommand`1") is not INamedTypeSymbol syncCmdRet ||
+            context.Compilation.GetTypeByMetadataName("Merq.IAsyncCommand`1") is not INamedTypeSymbol asyncCmdRet)
+            return;
+
+        if (namedType.DeclaredAccessibility == Accessibility.Public)
+            return;
+
+        if (namedType.Is(syncCmd) || namedType.Is(asyncCmd) || namedType.Is(syncCmdRet) || namedType.Is(asyncCmdRet))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.CommandTypesShouldBePublic,
+                namedType.Locations[0],
+                namedType.Name));
+        }
+    }
+}


### PR DESCRIPTION
Public commands types can use the C# dynamic dispatch which performs better than plain reflection, so issue a warning if they are not.

Closes #71