### PR TITLE
Add basic telemetry support in core message bus implementation

### DIFF
--- a/Merq.sln
+++ b/Merq.sln
@@ -44,6 +44,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Merq.AutoMapper", "src\Merq
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Merq.Dynamically", "src\Samples\Merq.Dynamically\Merq.Dynamically.csproj", "{2CA2D2DD-20EC-4BB8-B641-196BDBFB8D6E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "src\Samples\ConsoleApp\ConsoleApp.csproj", "{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,10 @@ Global
 		{2CA2D2DD-20EC-4BB8-B641-196BDBFB8D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CA2D2DD-20EC-4BB8-B641-196BDBFB8D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CA2D2DD-20EC-4BB8-B641-196BDBFB8D6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +121,7 @@ Global
 		{E72D5F5F-4A8B-4C00-9111-B7CCC9A33C09} = {9856158D-721E-4B4C-84CA-1FB3BB19B532}
 		{1D273A2C-E197-485B-82DC-82755D94C1D4} = {9856158D-721E-4B4C-84CA-1FB3BB19B532}
 		{2CA2D2DD-20EC-4BB8-B641-196BDBFB8D6E} = {9856158D-721E-4B4C-84CA-1FB3BB19B532}
+		{9D458376-9F9A-4F71-B659-0DA2C6B9A9B7} = {9856158D-721E-4B4C-84CA-1FB3BB19B532}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F401F53-1497-4C3F-BA2B-915F7560AF17}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,9 @@
 ﻿<Project>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="12.0.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.5" />
     <PackageVersion Include="Devlooped.Dynamically" Version="1.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" />
     <PackageVersion Include="NuGetizer" Version="0.9.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,6 +6,11 @@
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" />
     <PackageVersion Include="NuGetizer" Version="0.9.1" />
     <PackageVersion Include="IFluentInterface" Version="2.1.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.45.0" />
+    <PackageVersion Include="System.Composition.AttributedModel" Version="6.0.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     <PackageVersion Include="ThisAssembly.Project" Version="1.0.10" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
@@ -20,7 +25,7 @@
     <PackageVersion Include="SharpYaml" Version="2.1.0" />
     <PackageVersion Include="Scriban" Version="5.5.0" />
     <PackageVersion Include="Superpower" Version="3.0.0" />
-    <PackageVersion Include="Devlooped.Extensions.DependencyInjection.Attributed" Version="1.2.1" />
+    <PackageVersion Include="Devlooped.Extensions.DependencyInjection.Attributed" Version="1.2.2" />
     <PackageVersion Include="RxFree" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup Label="Tests">

--- a/src/Merq.AutoMapper/Merq.AutoMapper.csproj
+++ b/src/Merq.AutoMapper/Merq.AutoMapper.csproj
@@ -11,6 +11,11 @@
     <ProjectReference Include="..\Merq.Core\Merq.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="AutoMapper" VersionOverride="10.1.1" />
   </ItemGroup>

--- a/src/Merq.Core/Merq.Core.csproj
+++ b/src/Merq.Core/Merq.Core.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
     <PackageReference Include="RxFree" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Merq.Core/Subject.cs
+++ b/src/Merq.Core/Subject.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using static Merq.Telemetry;
 
 namespace System.Reactive.Subjects;
 
@@ -22,6 +23,7 @@ partial class Subject<T> : Subject
     {
         if (mapper == null)
         {
+            using var activity = StartActivity(typeof(T), "send");
             OnNext((T)value);
         }
         else if (maps.GetOrAdd(value.GetType(),
@@ -29,6 +31,7 @@ partial class Subject<T> : Subject
                 obj => (T)map(value) : null)
             is Func<object, T> map)
         {
+            using var activity = StartActivity(typeof(T), "send");
             OnNext(map(value));
         }
     }

--- a/src/Merq.Core/Telemetry.cs
+++ b/src/Merq.Core/Telemetry.cs
@@ -19,4 +19,15 @@ static class Telemetry
             ?.SetTag("messaging.operation", operation)
             ?.SetTag("messaging.protocol", type.Assembly.GetName().Name)
             ?.SetTag("messaging.protocol_version", type.Assembly.GetName().Version?.ToString() ?? "unknown");
+
+    public static void RecordException(this Activity? activity, Exception e)
+    {
+        // See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+        activity?.AddEvent(new ActivityEvent("exception", tags: new()
+        {
+            { "exception.message", e.Message },
+            { "exception.type", e.GetType().FullName },
+            { "exception.stacktrace", e.ToString() },
+        }));
+    }
 }

--- a/src/Merq.Core/Telemetry.cs
+++ b/src/Merq.Core/Telemetry.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Merq;
+
+static class Telemetry
+{
+    static readonly ActivitySource tracer = new(ThisAssembly.Project.AssemblyName, ThisAssembly.Project.Version);
+
+    public static Activity? StartActivity(Type type, string operation = "process", [CallerMemberName] string? member = default, [CallerFilePath] string? file = default, [CallerLineNumber] int? line = default)
+        => tracer.StartActivity(ActivityKind.Producer, name: $"{member}/{type.FullName}")
+            ?.SetTag("code.function", member)
+            ?.SetTag("code.filepath", file)
+            ?.SetTag("code.lineno", line)
+            ?.SetTag("messaging.system", "merq")
+            ?.SetTag("messaging.destination", type.FullName)
+            ?.SetTag("messaging.destination_kind", "topic")
+            ?.SetTag("messaging.operation", operation)
+            ?.SetTag("messaging.protocol", type.Assembly.GetName().Name)
+            ?.SetTag("messaging.protocol_version", type.Assembly.GetName().Version?.ToString() ?? "unknown");
+}

--- a/src/Merq.DependencyInjection/MerqServicesExtension.cs
+++ b/src/Merq.DependencyInjection/MerqServicesExtension.cs
@@ -19,7 +19,6 @@ static partial class MerqServicesExtension
     /// <param name="enableAutoMapping">Enables duck-typing behavior for events and commands, where 
     /// instances of disparate assemblies can observe and execute each other's events and commands 
     /// as long as their full type name matches.</param>
-    /// </param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddMessageBus(this IServiceCollection services, bool addDiscoveredServices = true, bool enableAutoMapping = false)
     {

--- a/src/Merq.VisualStudio.Tests/Merq.VisualStudio.Tests.csproj
+++ b/src/Merq.VisualStudio.Tests/Merq.VisualStudio.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
@@ -21,6 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Samples\Library1\Library1.csproj" Aliases="Library1" />
+    <ProjectReference Include="..\Samples\Library2\Library2.csproj" Aliases="Library2" />
     <ProjectReference Include="..\Merq.Tests\Merq.Tests.csproj" />
     <ProjectReference Include="..\Merq.VisualStudio\Merq.VisualStudio.csproj" />
   </ItemGroup>

--- a/src/Samples/ConsoleApp/ConsoleApp.csproj
+++ b/src/Samples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,40 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
+    <!-- Allow inspection of generated code under obj -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
+    <PackageReference Include="RxFree">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Spectre.Console" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Merq.AutoMapper\Merq.AutoMapper.csproj" />
+    <ProjectReference Include="..\Library1\Library1.csproj" Aliases="Library1" />
+    <ProjectReference Include="..\Library2\Library2.csproj" Aliases="Library2" />
+  </ItemGroup>
+
+  <!-- Item fixes to support project references vs package references -->
+  <ItemGroup Label="All items in this group aren't needed when referencing the nuget packages instead of project references">    
+    <!-- Analyzers and code fixes otherwise automatically added by Merq package -->
+    <ProjectReference Include="..\..\Merq.CodeAnalysis\Merq.CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\Merq.CodeFixes\Merq.CodeFixes.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <!-- Source included in Merq.DependencyInjection package to register message bus. -->
+    <Compile Include="..\..\Merq.DependencyInjection\MerqServicesExtension.cs" Link="MerqServicesExtension.cs" Visible="false" />
+    <!-- Dependency otherwise brought-in by Merq.DependencyInjection for automated service discovery and registration at compile-time. -->
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/ConsoleApp/ConsoleApp.csproj
+++ b/src/Samples/ConsoleApp/ConsoleApp.csproj
@@ -7,23 +7,28 @@
     <!-- Allow inspection of generated code under obj -->
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <UserSecretsId>55E4443F-538A-4BBF-898D-26F7E13F8508</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
-    <PackageReference Include="RxFree">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="RxFree" />
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="ThisAssembly.Project" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Merq.AutoMapper\Merq.AutoMapper.csproj" />
     <ProjectReference Include="..\Library1\Library1.csproj" Aliases="Library1" />
     <ProjectReference Include="..\Library2\Library2.csproj" Aliases="Library2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectProperty Include="UserSecretsId" />
   </ItemGroup>
 
   <!-- Item fixes to support project references vs package references -->

--- a/src/Samples/ConsoleApp/Program.cs
+++ b/src/Samples/ConsoleApp/Program.cs
@@ -1,0 +1,53 @@
+﻿extern alias Library1;
+extern alias Library2;
+using Merq;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using static Spectre.Console.AnsiConsole;
+
+// Initialize services
+var collection = new ServiceCollection();
+// Library1 contains [Service]-annotated classes, which will be automatically registered here.
+collection.AddMessageBus(addDiscoveredServices: true, enableAutoMapping: true);
+
+var services = collection.BuildServiceProvider();
+var bus = services.GetRequiredService<IMessageBus>();
+
+// Setup OpenTelemetry: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs
+using var tracer = Sdk
+    .CreateTracerProviderBuilder()
+    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("ConsoleApp"))
+    .AddSource("Merq.Core")
+    .AddSource("Merq.AutoMapper")
+    .AddConsoleExporter()
+    .AddZipkinExporter()
+    .Build();
+
+MarkupLine("[yellow]Executing with command from same assembly[/]");
+
+// NOTE: we subscribe to an event in Library2, which is (duck)compatible with the one 
+// notified by the Library1.Echo command handler!
+bus.Observe<Library2::Library.OnDidSay>()
+    .Subscribe(e => MarkupLine($"[red]Received Library2:{e.GetType().Name}.Message={e.Message}[/]"));
+
+// Also observe the original message, for comparison
+bus.Observe<Library1::Library.OnDidSay>()
+    .Subscribe(e => MarkupLine($"[lime]Received Library1:{e.GetType().Name}.Message={e.Message}[/]"));
+
+// We can execute passing an object of the same type/assembly as the EchoHandler expects
+var message = bus.Execute(new Library1::Library.Echo("Hello World"));
+
+WriteLine(message);
+
+MarkupLine("[yellow]Executing with command from different assembly[/]");
+
+// But we can also execute passing an object from an entirely different assembly
+message = bus.Execute(new Library2::Library.Echo("Hello World"));
+
+WriteLine(message);
+
+// Test rapid fire messages
+//Parallel.For(0, 10, i 
+//    => bus.Execute(new Library2::Library.Echo($"Hello World ({i})")));

--- a/src/Samples/Library1/Commands.cs
+++ b/src/Samples/Library1/Commands.cs
@@ -29,7 +29,7 @@ public class EchoHandler : ICommandHandler<Echo, string>
     readonly IMessageBus? bus;
 
     public EchoHandler() { }
-    
+
     public EchoHandler(IMessageBus bus) => this.bus = bus;
 
     public bool CanExecute(Echo command) => !string.IsNullOrEmpty(command.Message);
@@ -38,7 +38,7 @@ public class EchoHandler : ICommandHandler<Echo, string>
     {
         if (string.IsNullOrEmpty(command.Message))
             throw new NotSupportedException("Cannot echo an empty or null message");
-        
+
         bus?.Notify(new OnDidSay(command.Message));
         return command.Message;
     }

--- a/src/Samples/Library1/Events.cs
+++ b/src/Samples/Library1/Events.cs
@@ -13,3 +13,5 @@ public partial record Buffer(ICollection<Line> Lines);
 public partial record OnDidEdit(Buffer Buffer);
 
 public record OnDidDrawLine(Line Line);
+
+public partial record OnDidSay(string Message);

--- a/src/Samples/Library2/Events.cs
+++ b/src/Samples/Library2/Events.cs
@@ -16,3 +16,5 @@ public partial record OnDidDrawLine(Line Line)
 {
     //public static OnDidDrawLine Create(dynamic value) => new(Line.Create(value.Line));
 }
+
+public partial record OnDidSay(string Message);


### PR DESCRIPTION
Adds core Execute/Notify and CreateMapper telemetry. Also provides telemetry when notifying subjects.

The messaging "protocol" is specified as the assembly for the message type, and the protocol version, the assembly version. This will allow querying/tracking contracts being used.

Operations for Execute methods are `process` and for notify/onnext, `send` (since they are fire&forget notifications).

A new console app sample that showscases the features is also provided.

Closes #73