### PR TITLE
Add command and event payloads to activity

### DIFF
--- a/src/Merq.Core/MessageBus.cs
+++ b/src/Merq.Core/MessageBus.cs
@@ -190,7 +190,7 @@ public class MessageBus : IMessageBus
     public void Execute(ICommand command)
     {
         var type = GetCommandType(command);
-        using var activity = StartActivity(type, Telemetry.Process);
+        using var activity = StartCommandActivity(type, command);
 
         try
         {
@@ -222,7 +222,7 @@ public class MessageBus : IMessageBus
     public TResult Execute<TResult>(ICommand<TResult> command)
     {
         var type = GetCommandType(command);
-        using var activity = StartActivity(type, Telemetry.Process);
+        using var activity = StartCommandActivity(type, command);
 
         try
         {
@@ -253,7 +253,7 @@ public class MessageBus : IMessageBus
     public Task ExecuteAsync(IAsyncCommand command, CancellationToken cancellation = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartActivity(type, Telemetry.Process);
+        using var activity = StartCommandActivity(type, command);
 
         try
         {
@@ -286,7 +286,7 @@ public class MessageBus : IMessageBus
     public Task<TResult> ExecuteAsync<TResult>(IAsyncCommand<TResult> command, CancellationToken cancellation = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartActivity(type, Telemetry.Process);
+        using var activity = StartCommandActivity(type, command);
 
         try
         {
@@ -315,7 +315,7 @@ public class MessageBus : IMessageBus
     public void Notify<TEvent>(TEvent e)
     {
         var type = (e ?? throw new ArgumentNullException(nameof(e))).GetType();
-        using var activity = StartActivity(type, Publish);
+        using var activity = StartEventActivity(type, e);
         var watch = Stopwatch.StartNew();
 
         try

--- a/src/Samples/ConsoleApp/Program.cs
+++ b/src/Samples/ConsoleApp/Program.cs
@@ -36,12 +36,14 @@ var services = collection.BuildServiceProvider();
 var bus = services.GetRequiredService<IMessageBus>();
 
 // .NET-style activity listening
-//using var listener = new ActivityListener
-//{
-//    ActivityStarted = activity => MarkupLine($"[red]Activity started: {activity.OperationName}[/]"),
-//    ActivityStopped = activity => MarkupLine($"[red]Activity stopped: {activity.OperationName}[/]"),
-//    ShouldListenTo = source => source.Name == "Merq.Core",
-//};
+using var listener = new ActivityListener
+{
+    ActivityStarted = activity => MarkupLine($"[grey]Activity started: {activity.OperationName}[/]"),
+    ActivityStopped = activity => MarkupLine($"[grey]Activity stopped: {activity.OperationName}[/]"),
+    ShouldListenTo = source => source.Name == "Merq",
+};
+
+ActivitySource.AddActivityListener(listener);
 
 // Setup OpenTelemetry: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs
 using var tracer = Sdk


### PR DESCRIPTION
By exposing these as custom properties, we allow listeners to perform additional operations on them without having to extend the message bus itself.