### PR TITLE
Add caller information to main API for improved telemetry

### DIFF
--- a/src/Merq.Core/MessageBus.cs
+++ b/src/Merq.Core/MessageBus.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -183,14 +184,11 @@ public class MessageBus : IMessageBus
         return FindCommandMapper(type, out _) is not null;
     });
 
-    /// <summary>
-    /// Executes the given synchronous command.
-    /// </summary>
-    /// <param name="command">The command parameters for the execution.</param>
-    public void Execute(ICommand command)
+    /// <inheritdoc/>
+    public void Execute(ICommand command, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartCommandActivity(type, command);
+        using var activity = StartCommandActivity(type, command, callerName, callerFile, callerLine);
 
         try
         {
@@ -213,16 +211,11 @@ public class MessageBus : IMessageBus
         }
     }
 
-    /// <summary>
-    /// Executes the given synchronous command and returns a result from it.
-    /// </summary>
-    /// <typeparam name="TResult">The return type of the command execution.</typeparam>
-    /// <param name="command">The command parameters for the execution.</param>
-    /// <returns>The result of executing the command.</returns>
-    public TResult Execute<TResult>(ICommand<TResult> command)
+    /// <inheritdoc/>
+    public TResult Execute<TResult>(ICommand<TResult> command, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartCommandActivity(type, command);
+        using var activity = StartCommandActivity(type, command, callerName, callerFile, callerLine);
 
         try
         {
@@ -245,15 +238,11 @@ public class MessageBus : IMessageBus
         }
     }
 
-    /// <summary>
-    /// Executes the given asynchronous command.
-    /// </summary>
-    /// <param name="command">The command parameters for the execution.</param>
-    /// <param name="cancellation">Cancellation token to cancel command execution.</param>
-    public Task ExecuteAsync(IAsyncCommand command, CancellationToken cancellation = default)
+    /// <inheritdoc/>
+    public Task ExecuteAsync(IAsyncCommand command, CancellationToken cancellation = default, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartCommandActivity(type, command);
+        using var activity = StartCommandActivity(type, command, callerName, callerFile, callerLine);
 
         try
         {
@@ -276,17 +265,11 @@ public class MessageBus : IMessageBus
         }
     }
 
-    /// <summary>
-    /// Executes the given asynchronous command and returns a result from it.
-    /// </summary>
-    /// <typeparam name="TResult">The return type of the command execution.</typeparam>
-    /// <param name="command">The command parameters for the execution.</param>
-    /// <param name="cancellation">Cancellation token to cancel command execution.</param>
-    /// <returns>The result of executing the command.</returns>
-    public Task<TResult> ExecuteAsync<TResult>(IAsyncCommand<TResult> command, CancellationToken cancellation = default)
+    /// <inheritdoc/>
+    public Task<TResult> ExecuteAsync<TResult>(IAsyncCommand<TResult> command, CancellationToken cancellation = default, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
     {
         var type = GetCommandType(command);
-        using var activity = StartCommandActivity(type, command);
+        using var activity = StartCommandActivity(type, command, callerName, callerFile, callerLine);
 
         try
         {
@@ -309,13 +292,11 @@ public class MessageBus : IMessageBus
         }
     }
 
-    /// <summary>
-    /// Notifies the bus of an event.
-    /// </summary>
-    public void Notify<TEvent>(TEvent e)
+    /// <inheritdoc/>
+    public void Notify<TEvent>(TEvent e, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
     {
         var type = (e ?? throw new ArgumentNullException(nameof(e))).GetType();
-        using var activity = StartEventActivity(type, e);
+        using var activity = StartEventActivity(type, e, callerName, callerFile, callerLine);
         var watch = Stopwatch.StartNew();
 
         try
@@ -342,7 +323,7 @@ public class MessageBus : IMessageBus
             {
                 try
                 {
-                    subject.OnNext(e);
+                    subject.OnNext(e, callerName, callerFile, callerLine);
                 }
                 catch (Exception ex)
                 {

--- a/src/Merq/IMessageBus.cs
+++ b/src/Merq/IMessageBus.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,22 +42,31 @@ public interface IMessageBus
     /// Executes the given synchronous command.
     /// </summary>
     /// <param name="command">The command parameters for the execution.</param>
-    void Execute(ICommand command);
+    /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
+    /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
+    /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
+    void Execute(ICommand command, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Executes the given synchronous command and returns a result from it.
     /// </summary>
     /// <typeparam name="TResult">The return type of the command execution.</typeparam>
     /// <param name="command">The command parameters for the execution.</param>
+    /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
+    /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
+    /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
     /// <returns>The result of executing the command.</returns>
-    TResult Execute<TResult>(ICommand<TResult> command);
+    TResult Execute<TResult>(ICommand<TResult> command, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Executes the given asynchronous command.
     /// </summary>
     /// <param name="command">The command parameters for the execution.</param>
     /// <param name="cancellation">Cancellation token to cancel command execution.</param>
-    Task ExecuteAsync(IAsyncCommand command, CancellationToken cancellation = default);
+    /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
+    /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
+    /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
+    Task ExecuteAsync(IAsyncCommand command, CancellationToken cancellation = default, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Executes the given asynchronous command and returns a result from it.
@@ -64,13 +74,20 @@ public interface IMessageBus
     /// <typeparam name="TResult">The return type of the command execution.</typeparam>
     /// <param name="command">The command parameters for the execution.</param>
     /// <param name="cancellation">Cancellation token to cancel command execution.</param>
+    /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
+    /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
+    /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
     /// <returns>The result of executing the command.</returns>
-    Task<TResult> ExecuteAsync<TResult>(IAsyncCommand<TResult> command, CancellationToken cancellation = default);
+    Task<TResult> ExecuteAsync<TResult>(IAsyncCommand<TResult> command, CancellationToken cancellation = default, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Notifies the bus of an event.
     /// </summary>
-    void Notify<TEvent>(TEvent e);
+    /// <param name="e">The event to notify to potential subscribers.</param>
+    /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
+    /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
+    /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
+    void Notify<TEvent>(TEvent e, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Observes the events of a given type <typeparamref name="TEvent"/>.

--- a/src/Samples/ConsoleApp/Program.cs
+++ b/src/Samples/ConsoleApp/Program.cs
@@ -90,11 +90,11 @@ catch (NotSupportedException)
 }
 
 // Simulate long-running to collect telemetry from external process
-while (true)
-{
-    bus.Execute(new Library2::Library.Echo($"Hello World {Random.Shared.Next(0, 100)}"));
-    await Task.Delay(500);
-}
+//while (true)
+//{
+//    bus.Execute(new Library2::Library.Echo($"Hello World {Random.Shared.Next(0, 100)}"));
+//    await Task.Delay(500);
+//}
 
 // Test rapid fire messages
 //Parallel.For(0, 10, i 


### PR DESCRIPTION
The message bus will already produce activity start/stop for key API invocations (Execute/Notify). This telemetry currently includes the [recommended span code attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#source-code-attributes), but it will log the Merq locations for those.

This means that monitoring the activities for a message bus Execute/Notify invocation will reveal source attributes that belong to Merq, rather than the actual place where those invocations happened. It would be much more useful to have the telemetry attributes be associated with the caller than the bus itself in these cases. By propagating these automatically (for example, a bus.Execute where the command handler performs bus.Notify) we can precisely know where a given event handler delivery action originated in the actual upstream call to the bus itself, revealing a key codepath that can be invaluable for diagnostics.

From the point of view of the activity and telemetry, at least with regards to these source code attributes, the bus becomes "transparent" in a way. This is more useful than monitoring method and line # for the bus implementation itself.

Closes #102