### PR TITLE
Avoid losing caller information when invoking extension methods

### DIFF
--- a/src/Merq/IMessageBusExtensions.cs
+++ b/src/Merq/IMessageBusExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Merq;
 
@@ -11,13 +12,13 @@ public static class IMessageBusExtensions
     /// <summary>
     /// Notifies the bus of a new event instance of <typeparamref name="TEvent"/>.
     /// </summary>
-    public static void Notify<TEvent>(this IMessageBus bus) where TEvent : new()
-        => bus.Notify(new TEvent());
+    public static void Notify<TEvent>(this IMessageBus bus, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default) where TEvent : new()
+        => bus.Notify(new TEvent(), callerName, callerFile, callerLine);
 
     /// <summary>
     /// Executes the given synchronous command.
     /// </summary>
     /// <typeparam name="TCommand">The type of command to create and execute.</typeparam>
-    public static void Execute<TCommand>(this IMessageBus bus) where TCommand : ICommand, new()
-        => bus.Execute(new TCommand());
+    public static void Execute<TCommand>(this IMessageBus bus, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default) where TCommand : ICommand, new()
+        => bus.Execute(new TCommand(), callerName, callerFile, callerLine);
 }


### PR DESCRIPTION
The message bus extension methods for parameterless commands/events was missing the caller member arguments and thus causing an inconsistent behavior.