### PR TITLE
Fix automapper dependency

### DIFF
--- a/src/Merq.DependencyInjection/Merq.DependencyInjection.msbuildproj
+++ b/src/Merq.DependencyInjection/Merq.DependencyInjection.msbuildproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" TargetFramework="$(TargetFramework)" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Merq.AutoMapper\Merq.AutoMapper.csproj" />
+    <ProjectReference Include="..\Merq.AutoMapper\Merq.AutoMapper.csproj" TargetFramework="$(TargetFramework)" />
     <ProjectReference Include="..\Merq.Core\Merq.Core.csproj" />
     <ProjectReference Include="..\Merq\Merq.csproj" />
   </ItemGroup>


### PR DESCRIPTION
If we don't specify the target framework, the packaging project will just take a dependency with no framework. This doesn't work when we *also* have framework-specific dependencies, and will cause the dependency to be lost entirely when nuget performs a restore.

In other words, if you have non-framework specific dependencies AND framework specific dependencies, you will only get the latter in the restore graph.