### PR TITLE
Only set activity custom property when sampling AllData

### DIFF
--- a/src/Merq.Core/Telemetry.cs
+++ b/src/Merq.Core/Telemetry.cs
@@ -71,8 +71,11 @@ static class Telemetry
             ?.SetTag("messaging.protocol.name", type.Assembly.GetName().Name)
             ?.SetTag("messaging.protocol.version", type.Assembly.GetName().Version?.ToString() ?? "unknown");
 
-        if (property != null && value != null)
-            activity?.SetCustomProperty(property, value);
+        if (property != null && value != null &&
+            // Additional optimization so we don't incur allocation of activity custom props storage 
+            // unless someone is actually requesting the data. See https://github.com/open-telemetry/opentelemetry-dotnet/issues/1397 
+            activity?.IsAllDataRequested == true)
+            activity.SetCustomProperty(property, value);
 
         activity?.Start();
 

--- a/src/Merq.Tests/MessageBusSpec.cs
+++ b/src/Merq.Tests/MessageBusSpec.cs
@@ -478,7 +478,7 @@ public record MessageBusSpec(ITestOutputHelper Output)
                 if (a.GetTagItem("messaging.destination.name") is "Merq.CommandWithResult")
                     activity = a;
             },
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => _.Source.Name == "Merq" ? ActivitySamplingResult.AllData : ActivitySamplingResult.None,
             ShouldListenTo = source => source.Name == "Merq",
         };
 
@@ -497,7 +497,7 @@ public record MessageBusSpec(ITestOutputHelper Output)
         using var listener = new ActivityListener
         {
             ActivityStarted = x => activity = x,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => _.Source.Name == "Merq" ? ActivitySamplingResult.AllData : ActivitySamplingResult.None,
             ShouldListenTo = source => source.Name == "Merq",
         };
 


### PR DESCRIPTION
This optimization means we don't pay the extra allocation and cost unnecessarily unless someone is actually requesting all data from activities.

See https://github.com/open-telemetry/opentelemetry-dotnet/issues/1397