### PR TITLE
Rename Notify > NotifyAsync to allow async eventing scenarios

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # normalize by default
 * text=auto encoding=UTF-8
 *.sh text eol=lf
+*.sbn eol=lf
 
 # These are windows specific files which we may as well ensure are
 # always crlf on checkout

--- a/.github/actions/dotnet/action.yml
+++ b/.github/actions/dotnet/action.yml
@@ -1,0 +1,35 @@
+name: ⚙ dotnet
+description: Configures dotnet if the repo/org defines the DOTNET custom property
+
+runs:
+  using: composite
+  steps:
+    - name: 🔎 dotnet
+      id: dotnet
+      shell: bash
+      run: |
+        VERSIONS=$(gh api repos/${{ github.repository }}/properties/values | jq -r '.[] | select(.property_name == "DOTNET") | .value')
+        # Remove extra whitespace from VERSIONS
+        VERSIONS=$(echo "$VERSIONS" | tr -s ' ' | tr -d ' ')
+        # Convert comma-separated to newline-separated
+        NEWLINE_VERSIONS=$(echo "$VERSIONS" | tr ',' '\n')
+        # Validate versions
+        while IFS= read -r version; do
+          if ! [[ $version =~ ^[0-9]+(\.[0-9]+(\.[0-9]+)?)?(\.x)?$ ]]; then
+            echo "Error: Invalid version format: $version"
+            exit 1
+          fi
+        done <<< "$NEWLINE_VERSIONS"
+        # Write multiline output to $GITHUB_OUTPUT
+        {
+          echo 'versions<<EOF'
+          echo "$NEWLINE_VERSIONS"
+          echo 'EOF'
+        } >> $GITHUB_OUTPUT
+
+    - name: ⚙ dotnet
+      if: steps.dotnet.outputs.versions != ''
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          ${{ steps.dotnet.outputs.versions }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,6 @@ updates:
     ProtoBuf:
       patterns:
         - "protobuf-*"
+    Spectre:
+      patterns:
+        - "Spectre.Console*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MSBUILDTERMINALLOGGER: auto
   Configuration: ${{ github.event.inputs.configuration || 'Release' }}
+  SLEET_FEED_URL: ${{ vars.SLEET_FEED_URL }}
 
 defaults:
   run:
@@ -65,12 +66,7 @@ jobs:
           fetch-depth: 0
 
       - name: ⚙ dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            6.x
-            8.x
-            9.x
+        uses: ./.github/actions/dotnet
 
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog
@@ -103,6 +99,14 @@ jobs:
         with: 
           submodules: recursive
           fetch-depth: 0
+
+      - name: ⚙ dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.x
+            8.x
+            9.x
 
       - name: ✓ ensure format
         run: |

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -12,5 +12,10 @@ env:
 
 jobs:
   run:
+    permissions:
+      contents: write
     uses: devlooped/oss/.github/workflows/dotnet-file-core.yml@main
-    secrets: inherit
+    secrets: 
+      BOT_NAME: ${{ secrets.BOT_NAME }}
+      BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ env:
   VersionLabel: ${{ github.ref }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MSBUILDTERMINALLOGGER: auto
-    
+  SLEET_FEED_URL: https://api.nuget.org/v3/index.json
+      
 jobs:
   publish:
     runs-on: ${{ vars.PUBLISH_AGENT || 'ubuntu-latest' }}
@@ -27,12 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: ⚙ dotnet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            6.x
-            8.x
-            9.x
+        uses: ./.github/actions/dotnet
 
       - name: 🙏 build
         run: dotnet build -m:1 -bl:build.binlog

--- a/.netconfig
+++ b/.netconfig
@@ -25,17 +25,20 @@
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
 	sha = 5fb172362c767bef7c36478f1a6bdc264723f8f9
+
 	etag = ad1efa56d6024ee1add2bcda81a7e4e38d0e9069473c6ff70374d5ce06af1f5a
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
-	sha = 49661dbf0720cde93eb5569be7523b5912351560
-	etag = c147ea2f3431ca0338c315c4a45b56ee233c4d30f8d6ab698d0e1980a257fd6a
+	sha = 917ff5486e25bec90038e7ab6d146fd82c61f846
+
+	etag = 50bf50df5a6eeb1705baea50f4c6e06d167a89cb5a590887ff939bd4120bd442
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 59aaf432369b5ea597831d4feec5a6ac4024c2e3
-	etag = 1374e3f8c9b7af69c443605c03f7262300dcb7d783738d9eb9fe84268ed2d10c
+	sha = 8fa147d4799d73819040736c399d0b1db2c2d86c
+
+	etag = 1ca805a23656e99c03f9d478dba8ccef6e571f5de2ac0e9bb7e3c5216c99a694
 	weak
 [file "license.txt"]
 	url = https://github.com/devlooped/oss/blob/main/license.txt
@@ -49,17 +52,22 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = b76de49afb376aa48eb172963ed70663b59b31d3
-	etag = c8b56f3860cc7ccb8773b7bd6189f5c7a6e3a2c27e9104c1ee201fbdc5af9873
+	sha = 2fff747a9673b499c99f2da183cdd5263fdc9333
+
+	etag = 0fccddf04f282fe98122ab2610dc2972c205a521254559bf013655c6271b0017
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
 	sha = a8b208093599263b7f2d1fe3854634c588ea5199
+
 	etag = 19087699f05396205e6b050d999a43b175bd242f6e8fac86f6df936310178b03
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
-	skip
+	sha = 032439dbf180fca0539a5bd3a019f18ab3484b76
+
+	etag = da7c0104131bd474b52fc9bc9f9bda6470e24ae38d4fb9f5c4f719bc01370ab5
+	weak
 [file ".github/workflows/pages.yml"]
 	url = https://github.com/clarius/pages/blob/main/.github/workflows/pages.yml
 	sha = afcb0421af6507eba5ceba913b8fc37261efc085
@@ -68,44 +76,54 @@
 [file "Gemfile"]
 	url = https://github.com/clarius/pages/blob/main/Gemfile
 	sha = 90fa16ed0e7300a78a38ee1d23c34a7e875aab27
+
 	etag = 3dd7febc8ae6760f19abfe787711f469c288cd803a6f1c545edec34264d48e71
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
-	sha = 5f92a68e302bae675b394ef343114139c075993e
-	etag = 338ba6d92c8d1774363396739c2be4257bfc58026f4b0fe92cb0ae4460e1eff7
+	sha = 4a9aa321c4982b83c185cf8dffed181ff84667d5
+
+	etag = 09cad18280ed04b67f7f87591e5481510df04d44c3403231b8af885664d8fd58
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
 	weak
-	sha = 06e898ccba692566ebf845fa7c8833ac6c318c0a
-	etag = 0a4b3f0a875cd8c9434742b4046558aecf610d3fa3d490cfd2099266e95e9195
+	sha = 08c70776943839f73dbea2e65355108747468508
+
+	etag = fb2e91cdc9fb7a4d3e8f698e525816c5d8febb35b005c278eecca8056e78f809
 [file ".github/workflows/changelog.config"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.config
 	sha = 08d83cb510732f861416760d37702f9f55bd7f9e
+
 	etag = 556a28914eeeae78ca924b1105726cdaa211af365671831887aec81f5f4301b4
 	weak
 [file ".github/workflows/combine-prs.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/combine-prs.yml
-	skip
+	sha = c1610886eba42cb250e3894aed40c0a258cd383d
+	etag = 598ee294649a44d4c5d5934416c01183597d08aa7db7938453fd2bbf52a4e64d
+	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
 	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
+
 	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
 	weak
-	sha = 06e898ccba692566ebf845fa7c8833ac6c318c0a
-	etag = 2f64f75ad01f735fd05290370fb8a826111ac8dd7e74ce04226bb627a54a62ba
+	sha = 08c70776943839f73dbea2e65355108747468508
+
+	etag = 722a2c7cb3a42bc24ca7fb48d2e9a336641ed0599418239e24efbafccf64bd50
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
 	sha = e0be248fff1d39133345283b8227372b36574b75
+
 	etag = c449ec6f76803e1891357ca2b8b4fcb5b2e5deeff8311622fd92ca9fbf1e6575
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
 	sha = 0f7f7f7e8a29de9b535676f75fe7c67e629a5e8c
+
 	etag = 0ccae83fc51f400bfd7058170bfec7aba11455e24a46a0d7e6a358da6486e255
 	weak
 [file "_config.yml"]
@@ -121,13 +139,21 @@
 [file ".github/release.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/release.yml
 	sha = 0c23e24704625cf75b2cb1fdc566cef7e20af313
+
 	etag = 310df162242c95ed19ed12e3c96a65f77e558b46dced676ad5255eb12caafe75
 	weak
-[file ".github/workflows/triage.yml"]
-	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
-	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+[file ".github/actions/dotnet/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/actions/dotnet/action.yml
+	sha = f2b690ce307acb76c5b8d7faec1a5b971a93653e
+
+	etag = 27ea11baa2397b3ec9e643a935832da97719c4e44215cfd135c49cad4c29373f
 	weak
 [file ".github/workflows/dotnet-file-core.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml
 	skip
+[file ".github/workflows/triage.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
+	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
+
+	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+	weak

--- a/Merq.sln
+++ b/Merq.sln
@@ -3,18 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{235AA06D-5767-49D1-88F3-F25383FE1CAA}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		.netconfig = .netconfig
-		.github\workflows\build.yml = .github\workflows\build.yml
-		src\Directory.Packages.props = src\Directory.Packages.props
-		src\Directory.props = src\Directory.props
-		src\Directory.targets = src\Directory.targets
-		.github\workflows\publish.yml = .github\workflows\publish.yml
-		readme.md = readme.md
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Merq", "src\Merq\Merq.csproj", "{C6B16D17-4F6A-4457-8497-92068E53DE39}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Merq.Core", "src\Merq.Core\Merq.Core.csproj", "{33BDD9D1-3E01-49C1-AB46-50941DFFD5D4}"

--- a/readme.md
+++ b/readme.md
@@ -331,7 +331,7 @@ such as `ICommandHandler<T>` and `IObservable<TEvent>`.
 > lifetime.
 
 To drastically simplify registration of handlers and producers, we 
-recommend the [Devlooped.Extensions.DependencyInjection.Attributed](https://www.nuget.org/packages/Devlooped.Extensions.DependencyInjection.Attributed/).
+recommend the [Devlooped.Extensions.DependencyInjection](https://www.nuget.org/packages/Devlooped.Extensions.DependencyInjection/).
 package, which provides a simple attribute-based mechanism for automatically 
 emitting at compile-time the required service registrations for all types 
 marked with the provided `[Service]` attribute, which also allows setting the 
@@ -415,12 +415,12 @@ builder.Services.AddServices();
 
 # Dogfooding
 
-[![CI Version](https://img.shields.io/endpoint?url=https://shields.kzu.dev/vpre/Devlooped.Merq/main&label=nuget.ci&color=brightgreen)](https://pkg.kzu.dev/index.json)
+[![CI Version](https://img.shields.io/endpoint?url=https://shields.kzu.app/vpre/Merq/main&label=nuget.ci&color=brightgreen)](https://pkg.kzu.app/index.json)
 [![Build](https://github.com/devlooped/Merq/workflows/build/badge.svg?branch=main)](https://github.com/devlooped/Merq/actions)
 
 We also produce CI packages from branches and pull requests so you can dogfood builds as quickly as they are produced. 
 
-The CI feed is `https://pkg.kzu.dev/index.json`. 
+The CI feed is `https://pkg.kzu.app/index.json`. 
 
 The versioning scheme for packages is:
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -153,6 +153,18 @@
   <Import Project="Directory.props" Condition="Exists('Directory.props')"/>
   <Import Project="Directory.props.user" Condition="Exists('Directory.props.user')" />
 
+  <!-- If the imported props changed ManagePackageVersionsCentrally, we need to replicate 
+       the Version defaults from Microsoft.NET.DefaultAssemblyInfo.targets since it's too 
+       early here and Directory.Packages.props will be imported right after this time, 
+       meaning dependencies that expect to use the currently building Version would not 
+       get the expected value.
+   -->
+  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true' and '$(Version)' == ''">
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">1.0.0</VersionPrefix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
+  </PropertyGroup>
+
   <!-- Implemented by SDK in .targets, guaranteeing it's overwritten. Added here since we add a DependsOnTargets to it. 
        Covers backwards compatiblity with non-SDK projects. -->
   <Target Name="InitializeSourceControlInformation" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,51 +1,52 @@
 ﻿<Project>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="12.0.0" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.12" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
-    <PackageVersion Include="Devlooped.Dynamically" Version="1.0.3" />
-    <PackageVersion Include="MediatR" Version="12.2.0" />
-    <PackageVersion Include="Merq.DependencyInjection" Version="2.0.0-rc.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="NuGetizer" Version="1.0.5" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageVersion Include="Devlooped.Dynamically" Version="1.1.1" />
+    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="Merq.DependencyInjection" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageVersion Include="NuGetizer" Version="1.2.3" />
     <PackageVersion Include="IFluentInterface" Version="2.1.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageVersion Include="Spectre.Console" Version="0.45.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.9.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="6.0.0" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageVersion Include="ThisAssembly.Project" Version="2.0.11" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageVersion Include="ThisAssembly.AssemblyInfo" Version="2.0.8" />
+    <PackageVersion Include="ThisAssembly.Project" Version="2.0.8" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework" Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.3.198" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="6.0.0" />
-    <PackageVersion Include="PolySharp" Version="1.13.2" />
+    <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="SharpYaml" Version="2.1.1" />
-    <PackageVersion Include="Scriban" Version="5.5.0" />
+    <PackageVersion Include="Scriban" Version="5.11.0" />
     <PackageVersion Include="Superpower" Version="3.0.0" />
-    <PackageVersion Include="Devlooped.Extensions.DependencyInjection.Attributed" Version="1.3.2" />
-    <PackageVersion Include="RxFree" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="6.0.0" />
+    <PackageVersion Include="Devlooped.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageVersion Include="RxFree" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.EventSource" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup Label="Tests">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
-    <PackageVersion Include="Moq" Version="4.18.2" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.11.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
   </ItemGroup>
 </Project>

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <PackageProjectUrl>https://www.clarius.org/Merq</PackageProjectUrl>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName">

--- a/src/Merq.AutoMapper/Merq.AutoMapper.csproj
+++ b/src/Merq.AutoMapper/Merq.AutoMapper.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
@@ -24,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <PackageReference Include="AutoMapper" VersionOverride="12.0.0" />
+    <PackageReference Include="AutoMapper" VersionOverride="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Merq.Benchmarks/Merq.Benchmarks.csproj
+++ b/src/Merq.Benchmarks/Merq.Benchmarks.csproj
@@ -15,10 +15,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" PrivateAssets="all"/>
     <PackageReference Include="MediatR" />
     <PackageReference Include="Merq.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Merq.CodeAnalysis.Tests/CommandExecuteAnalyzerTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandExecuteAnalyzerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Test = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandExecuteAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
-using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandExecuteAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Test = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandExecuteAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandExecuteAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 
 namespace Merq;

--- a/src/Merq.CodeAnalysis.Tests/CommandExecuteFixerTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandExecuteFixerTests.cs
@@ -3,7 +3,6 @@ using Merq.CodeFixes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Merq;
 
@@ -12,7 +11,7 @@ public class CommandExecuteFixerTests
     [Fact]
     public async Task ExecuteSyncWithAsyncCommand()
     {
-        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -62,7 +61,7 @@ public class CommandExecuteFixerTests
     [Fact]
     public async Task ExecuteSyncWithAsyncReturnCommand()
     {
-        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -112,7 +111,7 @@ public class CommandExecuteFixerTests
     [Fact]
     public async Task ExecuteGenericSyncWithAsyncCommand()
     {
-        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, SyncToAsyncFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -162,7 +161,7 @@ public class CommandExecuteFixerTests
     [Fact]
     public async Task ExecuteAsyncWithSyncCommand()
     {
-        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, AsyncToSyncFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, AsyncToSyncFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -212,7 +211,7 @@ public class CommandExecuteFixerTests
     [Fact]
     public async Task ExecuteAsyncWithSyncReturnCommand()
     {
-        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, AsyncToSyncFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandExecuteAnalyzer, AsyncToSyncFixer, DefaultVerifier>
         {
             TestCode =
             """

--- a/src/Merq.CodeAnalysis.Tests/CommandFixerTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandFixerTests.cs
@@ -3,7 +3,6 @@ using Merq.CodeFixes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Merq;
 
@@ -12,7 +11,7 @@ public class CommandFixerTests
     [Fact]
     public async Task AddMissingCommandInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -58,7 +57,7 @@ public class CommandFixerTests
     [Fact]
     public async Task AddMissingCommandReturnInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -105,7 +104,7 @@ public class CommandFixerTests
     [Fact]
     public async Task AddMissingAsyncCommandInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -155,7 +154,7 @@ public class CommandFixerTests
     [Fact]
     public async Task AddMissingAsyncCommandReturnInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -206,7 +205,7 @@ public class CommandFixerTests
     [Fact]
     public async Task FixCommandReturnTypeInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -251,7 +250,7 @@ public class CommandFixerTests
     [Fact]
     public async Task FixAsyncCommandReturnTypeInterface()
     {
-        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandInterfaceAnalyzer, CommandInterfaceFixer, DefaultVerifier>
         {
             TestCode =
             """

--- a/src/Merq.CodeAnalysis.Tests/CommandHandlerAnalyzerTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandHandlerAnalyzerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Analyzer = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandHandlerAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
-using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandHandlerAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Analyzer = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandHandlerAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandHandlerAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Merq;
 

--- a/src/Merq.CodeAnalysis.Tests/CommandHandlerFixerTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandHandlerFixerTests.cs
@@ -3,7 +3,6 @@ using Merq.CodeFixes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Merq;
 
@@ -12,7 +11,7 @@ public class CommandHandlerFixerTests
     [Fact]
     public async Task AddHandlerReturnType()
     {
-        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -58,7 +57,7 @@ public class CommandHandlerFixerTests
     [Fact]
     public async Task AddAsyncHandlerReturnType()
     {
-        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -108,7 +107,7 @@ public class CommandHandlerFixerTests
     [Fact]
     public async Task FixHandlerReturnType()
     {
-        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, DefaultVerifier>
         {
             TestCode =
             """
@@ -155,7 +154,7 @@ public class CommandHandlerFixerTests
     [Fact]
     public async Task FixAsyncHandlerReturnType()
     {
-        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, XUnitVerifier>
+        var test = new CSharpCodeFixTest<CommandHandlerAnalyzer, CommandHandlerReturnFixer, DefaultVerifier>
         {
             TestCode =
             """

--- a/src/Merq.CodeAnalysis.Tests/CommandInterfaceTests.cs
+++ b/src/Merq.CodeAnalysis.Tests/CommandInterfaceTests.cs
@@ -2,9 +2,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
-using Analyzer = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandInterfaceAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
-using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandInterfaceAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Analyzer = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<Merq.CommandInterfaceAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Merq.CommandInterfaceAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 namespace Merq;
 
@@ -13,7 +12,7 @@ public class CommandInterfaceTests
     [Fact]
     public async Task NonPublicCommand()
     {
-        var test = new CSharpAnalyzerTest<PublicCommandAnalyzer, XUnitVerifier>
+        var test = new CSharpAnalyzerTest<PublicCommandAnalyzer, DefaultVerifier>
         {
             TestCode = """
             using Merq;

--- a/src/Merq.CodeAnalysis.Tests/Merq.CodeAnalysis.Tests.csproj
+++ b/src/Merq.CodeAnalysis.Tests/Merq.CodeAnalysis.Tests.csproj
@@ -9,12 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="PolySharp" />
-    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Merq.CodeAnalysis.Tests/TestExtensions.cs
+++ b/src/Merq.CodeAnalysis.Tests/TestExtensions.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Merq;
 
 public static class TestExtensions
 {
-    public static TTest WithMerq<TTest>(this TTest test) where TTest : AnalyzerTest<XUnitVerifier>
+    public static TTest WithMerq<TTest>(this TTest test) where TTest : AnalyzerTest<DefaultVerifier>
     {
         test.SolutionTransforms.Add((solution, projectId)
             => solution

--- a/src/Merq.CodeAnalysis/Merq.CodeAnalysis.csproj
+++ b/src/Merq.CodeAnalysis/Merq.CodeAnalysis.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" />
     <PackageReference Include="Microsoft.CSharp" />

--- a/src/Merq.CodeFixes/Merq.CodeFixes.csproj
+++ b/src/Merq.CodeFixes/Merq.CodeFixes.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Pack="false" />

--- a/src/Merq.Core/Merq.Core.csproj
+++ b/src/Merq.Core/Merq.Core.csproj
@@ -14,11 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
-    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" PrivateAssets="all" />
     <PackageReference Include="RxFree" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Merq.Core/Telemetry.cs
+++ b/src/Merq.Core/Telemetry.cs
@@ -7,8 +7,8 @@ namespace Merq;
 
 static class Telemetry
 {
-    static readonly ActivitySource tracer = new("Merq", ThisAssembly.Project.Version);
-    static Meter Meter { get; } = new Meter("Merq", ThisAssembly.Project.Version);
+    static readonly ActivitySource tracer = new("Merq", ThisAssembly.Info.Version);
+    static Meter Meter { get; } = new Meter("Merq", ThisAssembly.Info.Version);
 
     static readonly Counter<long> commands;
     static readonly Counter<long> events;

--- a/src/Merq.DependencyInjection/Merq.DependencyInjection.msbuildproj
+++ b/src/Merq.DependencyInjection/Merq.DependencyInjection.msbuildproj
@@ -10,7 +10,6 @@
     <Content Include="Merq.DependencyInjection.targets" PackFolder="build" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Merq.Tests/DuckTyping.cs
+++ b/src/Merq.Tests/DuckTyping.cs
@@ -53,7 +53,7 @@ public abstract class DuckTyping
 
 #if NET6_0_OR_GREATER
     [Fact]
-    public void ConvertEvent()
+    public async Task ConvertEvent()
     {
         var bus = CreateMessageBus();
         string? message = null;
@@ -61,13 +61,13 @@ public abstract class DuckTyping
         bus.Observe<Library1::Library.DuckEvent>()
             .Subscribe(e => message = e.Message);
 
-        bus.Notify(new Library2::Library.DuckEvent("Foo"));
+        await bus.NotifyAsync(new Library2::Library.DuckEvent("Foo"));
 
         Assert.Equal("Foo", message);
     }
 
     [Fact]
-    public void ConvertEventHierarchy()
+    public async Task ConvertEventHierarchy()
     {
         var bus = CreateMessageBus();
         int sumstarts = 0;
@@ -75,7 +75,7 @@ public abstract class DuckTyping
         bus.Observe<Library1::Library.OnDidEdit>()
             .Subscribe(e => sumstarts = e.Buffer.Lines.Select(l => l.Start).Sum(p => p.X));
 
-        bus.Notify(new Library2::Library.OnDidEdit(
+        await bus.NotifyAsync(new Library2::Library.OnDidEdit(
             new Library2::Library.Buffer(new[]
             {
                 new Library2::Library.Line(new Library2::Library.Point(1, 2), new Library2::Library.Point(3, 4)) ,
@@ -86,7 +86,7 @@ public abstract class DuckTyping
     }
 
     [Fact]
-    public void CustomConvertEvent()
+    public async Task CustomConvertEvent()
     {
         var bus = CreateMessageBus();
         Library2::Library.Line? line = null;
@@ -94,7 +94,7 @@ public abstract class DuckTyping
         bus.Observe<Library2::Library.OnDidDrawLine>()
             .Subscribe(e => line = e.Line);
 
-        bus.Notify(new Library1::Library.OnDidDrawLine(new Library1::Library.Line(new Library1::Library.Point(1, 2), new Library1::Library.Point(3, 4))));
+        await bus.NotifyAsync(new Library1::Library.OnDidDrawLine(new Library1::Library.Line(new Library1::Library.Point(1, 2), new Library1::Library.Point(3, 4))));
 
         Assert.NotNull(line);
         Assert.Equal(1, line.Start.X);

--- a/src/Merq.Tests/GeneratorTests.cs
+++ b/src/Merq.Tests/GeneratorTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Merq;
 
-public record GeneratorTests(ITestOutputHelper Output)
+public class GeneratorTests(ITestOutputHelper Output)
 {
     [Fact]
     public void CanRegisterProjectReferenceHandler()

--- a/src/Merq.Tests/Merq.Tests.csproj
+++ b/src/Merq.Tests/Merq.Tests.csproj
@@ -19,12 +19,11 @@
   <ItemGroup>
     <PackageReference Include="Devlooped.Dynamically" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="PolySharp" />
-    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Merq.VisualStudio.Tests/Merq.VisualStudio.Tests.csproj
+++ b/src/Merq.VisualStudio.Tests/Merq.VisualStudio.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" />
     <PackageReference Include="PolySharp" />
-    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Merq.VisualStudio.Tests/MessageBusComponentSpec.cs
+++ b/src/Merq.VisualStudio.Tests/MessageBusComponentSpec.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition.Primitives;
 using System.Reactive.Subjects;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Shell;
@@ -12,7 +13,7 @@ using Moq;
 
 namespace Merq;
 
-public record MessageBusComponentSpec(ITestOutputHelper Output)
+public class MessageBusComponentSpec(ITestOutputHelper Output)
 {
     [Fact]
     public async Task ComposeAsync()
@@ -43,6 +44,10 @@ public record MessageBusComponentSpec(ITestOutputHelper Output)
         MockComponentModel.Provider = exportProvider;
 
         var bus = exportProvider.GetExportedValue<IMessageBus>();
+
+        var services = new ServiceCollection();
+        services.AddKeyedTransient("Merq.IMessageBus.Default", (s, k) => new Lazy<IMessageBus>(
+            () => s.GetRequiredKeyedService<global::Merq.MessageBusComponent>(k)));
 
         Assert.NotNull(bus);
 

--- a/src/Merq.VisualStudio/Merq.VisualStudio.csproj
+++ b/src/Merq.VisualStudio/Merq.VisualStudio.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
     <PackageReference Include="System.ComponentModel.Composition" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />

--- a/src/Merq.VisualStudio/readme.md
+++ b/src/Merq.VisualStudio/readme.md
@@ -37,11 +37,32 @@ class MyComponent
     {
         // do something, perhaps execute some command?
         bus.Execute(new MyCommand("Hello World"));
-
-        // perhaps raise further events?
-        bus.Notify(new MyOtherEvent());
     }
 }
+```
+
+If the event handler needs to be async for some reason (i.e. you're pushing 
+additional events or executing async commands), you can use the following pattern:
+
+```csharp
+    [ImportingConstructor]
+    public MyComponent(IMessageBus bus)
+    {
+        this.bus = bus;
+        
+        bus.Observe<ConcreteEvent>()
+           .Select(value => Observable.FromAsync(async () => await OnSolutionOpened(value)))
+           .Subscribe();
+    }
+
+    async Task OnSolutionOpened(ConcreteEvent e)
+    {
+        // do something, perhaps execute some command?
+        await bus.ExecuteAsync(new MyCommand("Hello World"));
+
+        // perhaps raise further events?
+        await bus.NotifyAsync(new MyEvent(42));
+    }
 ```
 
 To export command handlers to VS, you must export them with the relevant interface 

--- a/src/Merq/IMessageBus.cs
+++ b/src/Merq/IMessageBus.cs
@@ -103,7 +103,7 @@ public interface IMessageBus
     /// <param name="callerName">Optional calling member name, provided by default by the compiler.</param>
     /// <param name="callerFile">Optional calling file name, provided by default by the compiler.</param>
     /// <param name="callerLine">Optional calling line number, provided by default by the compiler.</param>
-    void Notify<TEvent>(TEvent e, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
+    ValueTask NotifyAsync<TEvent>(TEvent e, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default);
 
     /// <summary>
     /// Observes the events of a given type <typeparamref name="TEvent"/>.

--- a/src/Merq/IMessageBusExtensions.cs
+++ b/src/Merq/IMessageBusExtensions.cs
@@ -1,5 +1,8 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Merq;
 
@@ -10,10 +13,30 @@ namespace Merq;
 public static class IMessageBusExtensions
 {
     /// <summary>
+    /// Notifies the bus of an event.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use await NotifyAsync instead.")]
+    public static void Notify<TEvent>(this IMessageBus bus, TEvent e, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default)
+    {
+        var result = bus.NotifyAsync(e, callerName, callerFile, callerLine);
+        while (!result.IsCompleted)
+            Thread.SpinWait(1);
+    }
+
+    /// <summary>
     /// Notifies the bus of a new event instance of <typeparamref name="TEvent"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use await NotifyAsync instead.")]
     public static void Notify<TEvent>(this IMessageBus bus, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default) where TEvent : new()
         => bus.Notify(new TEvent(), callerName, callerFile, callerLine);
+
+    /// <summary>
+    /// Notifies the bus of a new event instance of <typeparamref name="TEvent"/>.
+    /// </summary>
+    public static ValueTask NotifyAsync<TEvent>(this IMessageBus bus, [CallerMemberName] string? callerName = default, [CallerFilePath] string? callerFile = default, [CallerLineNumber] int? callerLine = default) where TEvent : new()
+        => bus.NotifyAsync(new TEvent(), callerName, callerFile, callerLine);
 
     /// <summary>
     /// Executes the given synchronous command.

--- a/src/Merq/IStreamCommand.cs
+++ b/src/Merq/IStreamCommand.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
+﻿#if NET6_0_OR_GREATER
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Merq;
-
-#if NET6_0_OR_GREATER
 
 /// <summary>
 /// Marker interface for asynchronous commands whose execution results in a 
@@ -32,5 +31,4 @@ public interface IStreamCommandHandler<in TCommand, out TResult> : ICanExecute<T
     /// <returns>The result of the execution.</returns>
     IAsyncEnumerable<TResult> ExecuteSteam(TCommand command, CancellationToken cancellation);
 }
-
 #endif

--- a/src/Merq/Merq.csproj
+++ b/src/Merq/Merq.csproj
@@ -15,15 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="PublicAPI\net6.0\PublicAPI.Shipped.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="NuGetizer" />
-    <PackageReference Include="ThisAssembly.Project" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Pack="false" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Condition="$(TargetFramework) == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,7 +37,6 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" Condition="Exists('PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt')" />
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt')" />
-    <AdditionalFiles Include="PublicAPI\net6.0\PublicAPI.Shipped.txt" />
   </ItemGroup>
 
 </Project>

--- a/src/Merq/PublicAPI.Shipped.txt
+++ b/src/Merq/PublicAPI.Shipped.txt
@@ -28,8 +28,10 @@ Merq.IMessageBus.Execute(Merq.ICommand! command, string? callerName = null, stri
 Merq.IMessageBus.Execute<TResult>(Merq.ICommand<TResult>! command, string? callerName = null, string? callerFile = null, int? callerLine = null) -> TResult
 Merq.IMessageBus.ExecuteAsync(Merq.IAsyncCommand! command, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken), string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Threading.Tasks.Task!
 Merq.IMessageBus.ExecuteAsync<TResult>(Merq.IAsyncCommand<TResult>! command, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken), string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Threading.Tasks.Task<TResult>!
-Merq.IMessageBus.Notify<TEvent>(TEvent e, string? callerName = null, string? callerFile = null, int? callerLine = null) -> void
+Merq.IMessageBus.NotifyAsync<TEvent>(TEvent e, string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Threading.Tasks.ValueTask
 Merq.IMessageBus.Observe<TEvent>() -> System.IObservable<TEvent>!
 Merq.IMessageBusExtensions
 static Merq.IMessageBusExtensions.Execute<TCommand>(this Merq.IMessageBus! bus, string? callerName = null, string? callerFile = null, int? callerLine = null) -> void
 static Merq.IMessageBusExtensions.Notify<TEvent>(this Merq.IMessageBus! bus, string? callerName = null, string? callerFile = null, int? callerLine = null) -> void
+static Merq.IMessageBusExtensions.Notify<TEvent>(this Merq.IMessageBus! bus, TEvent e, string? callerName = null, string? callerFile = null, int? callerLine = null) -> void
+static Merq.IMessageBusExtensions.NotifyAsync<TEvent>(this Merq.IMessageBus! bus, string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Threading.Tasks.ValueTask

--- a/src/Merq/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Merq/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Merq.IStreamCommand<TResult>
+Merq.IStreamCommandHandler<TCommand, TResult>
+Merq.IStreamCommandHandler<TCommand, TResult>.ExecuteSteam(TCommand command, System.Threading.CancellationToken cancellation) -> System.Collections.Generic.IAsyncEnumerable<TResult>!
+Merq.IMessageBus.ExecuteStream<TResult>(Merq.IStreamCommand<TResult>! command, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken), string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Collections.Generic.IAsyncEnumerable<TResult>!

--- a/src/Merq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Merq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,0 @@
-Merq.IStreamCommand<TResult>
-Merq.IStreamCommandHandler<TCommand, TResult>
-Merq.IStreamCommandHandler<TCommand, TResult>.ExecuteSteam(TCommand command, System.Threading.CancellationToken cancellation) -> System.Collections.Generic.IAsyncEnumerable<TResult>!
-Merq.IMessageBus.ExecuteStream<TResult>(Merq.IStreamCommand<TResult>! command, System.Threading.CancellationToken cancellation = default(System.Threading.CancellationToken), string? callerName = null, string? callerFile = null, int? callerLine = null) -> System.Collections.Generic.IAsyncEnumerable<TResult>!

--- a/src/Samples/ConsoleApp/ConsoleApp.csproj
+++ b/src/Samples/ConsoleApp/ConsoleApp.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
     <PackageReference Include="RxFree" />
     <PackageReference Include="Spectre.Console" />
-    <PackageReference Include="ThisAssembly.Project" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +40,7 @@
     <!-- Source included in Merq.DependencyInjection package to register message bus. -->
     <Compile Include="..\..\Merq.DependencyInjection\MerqServicesExtension.cs" Link="MerqServicesExtension.cs" Visible="false" />
     <!-- Dependency otherwise brought-in by Merq.DependencyInjection for automated service discovery and registration at compile-time. -->
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/ConsoleApp/Program.cs
+++ b/src/Samples/ConsoleApp/Program.cs
@@ -13,7 +13,7 @@ using static Spectre.Console.AnsiConsole;
 
 var source = new ActivitySource("ConsoleApp");
 var config = new ConfigurationBuilder()
-    .AddUserSecrets(ThisAssembly.Project.UserSecretsId)
+    .AddUserSecrets<Program>()
     .Build();
 
 // Initialize services

--- a/src/Samples/Library1/Library1.csproj
+++ b/src/Samples/Library1/Library1.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="PolySharp" PrivateAssets="all" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" PrivateAssets="all" />
     <PackageReference Include="Devlooped.Dynamically" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Samples/Library2/Library2.csproj
+++ b/src/Samples/Library2/Library2.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="PolySharp" PrivateAssets="all" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" PrivateAssets="all" />
     <PackageReference Include="Devlooped.Dynamically" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Samples/Sample/Merq.Sample.csproj
+++ b/src/Samples/Sample/Merq.Sample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="PolySharp" PrivateAssets="all" />
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+      <add key="signatureValidationMode" value="accept" />
+    </config>
+    <trustedSigners>
+      <author name="Microsoft">
+        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="566A31882BE208BE4422F7CFD66ED09F5D4524A5994F50CCC8B05EC0528C1353" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </author>
+      <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </repository>
+    </trustedSigners>
+</configuration>


### PR DESCRIPTION
The previous API assumed in-process event notifications, which would prevent an implementation of the IMessageBus from using async event pub/sub mechanisms (i.e. EventGrid or message queues, etc.).

Using ValueTask allows reduced allocations for the default implementation of MessageBus which does precisely this (invoke handlers in-proc).