### PR TITLE
Align with latest messaging semantic conventions in OTEL

### DIFF
--- a/src/Merq/MessageBus.cs
+++ b/src/Merq/MessageBus.cs
@@ -369,7 +369,7 @@ public class MessageBus(IServiceProvider services) : IMessageBus
         }
         finally
         {
-            Publishing.Record(watch.ElapsedMilliseconds, new Tag("Event", type.FullName));
+            Sending.Record(watch.ElapsedMilliseconds, new Tag("Event", type.FullName));
         }
     }
 


### PR DESCRIPTION
Align with latest messaging semantic conventions in OTEL

See https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#operation-types and https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#span-name