### PR TITLE
Drop mention of ICanExecute registration

### DIFF
--- a/src/Merq.Tests/MessageBusSpec.cs
+++ b/src/Merq.Tests/MessageBusSpec.cs
@@ -32,7 +32,6 @@ public class MessageBusSpec(ITestOutputHelper Output)
 
         var bus = new MessageBus(new ServiceCollection()
             .AddSingleton<IStreamCommandHandler<StreamCommand, int>>(handler)
-            .AddSingleton<ICanExecute<StreamCommand>>(handler)
             .BuildServiceProvider());
 
         Assert.True(bus.CanHandle(command));

--- a/src/Merq/MessageBus.cs
+++ b/src/Merq/MessageBus.cs
@@ -26,8 +26,6 @@ namespace Merq;
 /// they implement.
 /// <para>
 /// Command handlers, in turn, need to be registered with:
-/// * <see cref="ICanExecute{TCommand}"/>: to properly respond to invocations of 
-/// <see cref="IMessageBus.CanExecute{TCommand}(TCommand)"/>
 /// * <see cref="ICommandHandler{TCommand}"/>, <see cref="ICommandHandler{TCommand, TResult}"/>, 
 /// <see cref="IAsyncCommandHandler{TCommand}"/> or <see cref="IAsyncCommandHandler{TCommand, TResult}"/> 
 /// according to the corresponding marker interface implemented by the <c>TCommand</c> 


### PR DESCRIPTION
We don't actually use that anymore, and we rather just get the actual handler and cast it to ICanExecute appropriately.